### PR TITLE
Fixing Date/DateTime bug when sending input to ManyWho

### DIFF
--- a/src/classes/ManyWhoObjectUtils.cls
+++ b/src/classes/ManyWhoObjectUtils.cls
@@ -1,5 +1,8 @@
 public class ManyWhoObjectUtils
 {
+    static final String DATE_TYPE = 'DATE';
+    static final String DATETIME_TYPE = 'DATETIME';
+    
     public static SObject getFullSObjectRecord(String objectName, String objectID) {
 
         return Database.query(getSelectById(objectName, objectID));
@@ -83,7 +86,7 @@ public class ManyWhoObjectUtils
     }
     
     public static ManyWhoAPI.TypeElementRequestAPI createMType(SObject s_object) {
-    	
+        
         Map<String, Schema.SObjectField> fieldMap = null;
         List<ManyWhoAPI.ObjectAPI> m_objects = null;
         ManyWhoAPI.TypeElementRequestAPI m_type = null;
@@ -106,8 +109,23 @@ public class ManyWhoObjectUtils
 
                 Schema.DescribeFieldResult dfield = sfield.getDescribe();
                 ManyWhoAPI.PropertyAPI property = null;
+                String value = String.valueOf(s_object.get(dfield.getName()));
 
-                property = new ManyWhoAPI.PropertyAPI(dfield.getLabel(), String.valueOf(s_object.get(dfield.getName())));
+                if(dfield.getType().name() == DATE_TYPE) {
+
+                    Date d = Date.valueOf(s_object.get(dfield.getName()));
+                    if(value != null)
+                        value = value.replace(' 00:00:00', '');
+
+                } else if(dfield.getType().name() == DATETIME_TYPE) {
+
+                    DateTime dt = DateTime.valueOf(s_object.get(dfield.getName()));
+                    if(dt != null)
+                        value = dt.format('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
+
+                }
+
+                property = new ManyWhoAPI.PropertyAPI(dfield.getLabel(), value);
                 
                 m_object.properties.Add(property);
 
@@ -125,15 +143,15 @@ public class ManyWhoObjectUtils
 
         if (fieldMap != null &&
             s_object != null) {
-            	
+                
             String objectName = getSObjectName(s_object);
 
-			// Create the binding for the Type            
+            // Create the binding for the Type            
             m_typeBinding = new ManyWhoAPI.TypeElementBindingAPI();
-	        m_typeBinding.developerName = 'Salesforce ' + objectName;
-	        m_typeBinding.developerSummary = 'The binding for ' + objectName;
-	        m_typeBinding.databaseTableName = objectName;
-	        m_typeBinding.propertyBindings = new List<ManyWhoAPI.TypeElementPropertyBindingAPI>();
+            m_typeBinding.developerName = 'Salesforce ' + objectName;
+            m_typeBinding.developerSummary = 'The binding for ' + objectName;
+            m_typeBinding.databaseTableName = objectName;
+            m_typeBinding.propertyBindings = new List<ManyWhoAPI.TypeElementPropertyBindingAPI>();
             
             // Create the root Type
             m_type = new ManyWhoAPI.TypeElementRequestAPI(getSObjectLabel(s_object), null);            
@@ -146,10 +164,10 @@ public class ManyWhoObjectUtils
                 ManyWhoAPI.TypeElementPropertyAPI property = null;
                 ManyWhoAPI.TypeElementPropertyBindingAPI propertyBinding = null;
 
-				// Create the root property
+                // Create the root property
                 property = new ManyWhoAPI.TypeElementPropertyAPI(dfield.getLabel(), getContentTypeForDisplayType(String.valueOf(dfield.getType())));
 
-				// Create the data binding
+                // Create the data binding
                 propertyBinding = new ManyWhoAPI.TypeElementPropertyBindingAPI(dfield.getName(), dfield.getLabel(), String.valueOf(dfield.getType()));
                 
                 m_type.properties.Add(property);
@@ -202,10 +220,10 @@ public class ManyWhoObjectUtils
     }
     
     private static String getContentTypeForDisplayType(String displayType) {
-    	
-    	String contentType = null;
+        
+        String contentType = null;
 
-    	displayType = displayType.toLowerCase();
+        displayType = displayType.toLowerCase();
 
         if ('string' == displayType ||
             'id' == displayType ||
@@ -237,7 +255,7 @@ public class ManyWhoObjectUtils
         }
         else
         {
-        	// Anything else is a string to ManyWho
+            // Anything else is a string to ManyWho
             contentType = ManyWhoAPI.CONTENT_TYPE_STRING;
         }
 

--- a/src/classes/ManyWhoObjectUtils.cls
+++ b/src/classes/ManyWhoObjectUtils.cls
@@ -9,6 +9,20 @@ public class ManyWhoObjectUtils
 
     }
 
+    public static List<SObject> getFullSObjectRecords(String objectName, List<String> objectIDs) {
+
+        return Database.query(getSelectByIds(objectName, objectIDs));
+
+    }
+
+    public static List<SObject> getFullSObjectRecords(String objectName, String whereClause) {
+
+        system.debug('soql: ' + getSelectByIds(objectName, whereClause));
+
+        return Database.query(getSelectByIds(objectName, whereClause));
+
+    }
+
     public static List<SObject> getSObjectRecords(String soql) {
 
         return Database.query(soql);
@@ -20,6 +34,26 @@ public class ManyWhoObjectUtils
         String soql = getSelectAll(objectName);
         
         soql += ' WHERE Id = \'' + objectID + '\'';
+
+        return soql;
+
+    }
+
+    public static String getSelectByIds(String objectName, List<String> objectIDs) {
+
+        String soql = getSelectAll(objectName);
+        
+        soql += ' WHERE Id IN (\'' + String.join(objectIDs, '\',\'') + '\')';
+
+        return soql;
+
+    }
+
+    public static String getSelectByIds(String objectName, String whereClause) {
+
+        String soql = getSelectAll(objectName);
+        
+        soql += whereClause;
 
         return soql;
 

--- a/src/classes/ManyWhoObjectUtils.cls
+++ b/src/classes/ManyWhoObjectUtils.cls
@@ -9,20 +9,6 @@ public class ManyWhoObjectUtils
 
     }
 
-    public static List<SObject> getFullSObjectRecords(String objectName, List<String> objectIDs) {
-
-        return Database.query(getSelectByIds(objectName, objectIDs));
-
-    }
-
-    public static List<SObject> getFullSObjectRecords(String objectName, String whereClause) {
-
-        system.debug('soql: ' + getSelectByIds(objectName, whereClause));
-
-        return Database.query(getSelectByIds(objectName, whereClause));
-
-    }
-
     public static List<SObject> getSObjectRecords(String soql) {
 
         return Database.query(soql);
@@ -34,26 +20,6 @@ public class ManyWhoObjectUtils
         String soql = getSelectAll(objectName);
         
         soql += ' WHERE Id = \'' + objectID + '\'';
-
-        return soql;
-
-    }
-
-    public static String getSelectByIds(String objectName, List<String> objectIDs) {
-
-        String soql = getSelectAll(objectName);
-        
-        soql += ' WHERE Id IN (\'' + String.join(objectIDs, '\',\'') + '\')';
-
-        return soql;
-
-    }
-
-    public static String getSelectByIds(String objectName, String whereClause) {
-
-        String soql = getSelectAll(objectName);
-        
-        soql += whereClause;
 
         return soql;
 

--- a/src/classes/ManyWhoObjectUtils_Tests.cls
+++ b/src/classes/ManyWhoObjectUtils_Tests.cls
@@ -14,6 +14,14 @@ public class ManyWhoObjectUtils_Tests {
         // Execute the call for all objects
         List<SObject> s_objects = ManyWhoObjectUtils.getSObjectRecords(ManyWhoObjectUtils.getSelectAll('Case'));
         List<ManyWhoAPI.ObjectAPI> m_objects = ManyWhoObjectUtils.createMList(s_objects);
+
+        // Execute the call for all objects with input List
+        s_objects = ManyWhoObjectUtils.getFullSObjectRecords('Case', new List<Id>{c.Id});
+        m_objects = ManyWhoObjectUtils.createMList(s_objects);
+
+        // Execute the call for all objects with a where clause
+        s_objects = ManyWhoObjectUtils.getFullSObjectRecords('Case', ' WHERE Id IN (\'' + c.Id + '\')');
+        m_objects = ManyWhoObjectUtils.createMList(s_objects);
     }
 
 }

--- a/src/classes/ManyWhoObjectUtils_Tests.cls
+++ b/src/classes/ManyWhoObjectUtils_Tests.cls
@@ -14,14 +14,6 @@ public class ManyWhoObjectUtils_Tests {
         // Execute the call for all objects
         List<SObject> s_objects = ManyWhoObjectUtils.getSObjectRecords(ManyWhoObjectUtils.getSelectAll('Case'));
         List<ManyWhoAPI.ObjectAPI> m_objects = ManyWhoObjectUtils.createMList(s_objects);
-
-        // Execute the call for all objects with input List
-        s_objects = ManyWhoObjectUtils.getFullSObjectRecords('Case', new List<Id>{c.Id});
-        m_objects = ManyWhoObjectUtils.createMList(s_objects);
-
-        // Execute the call for all objects with a where clause
-        s_objects = ManyWhoObjectUtils.getFullSObjectRecords('Case', ' WHERE Id IN (\'' + c.Id + '\')');
-        m_objects = ManyWhoObjectUtils.createMList(s_objects);
     }
 
 }


### PR DESCRIPTION
ManyWho is currently unable to interpret Date and DateTime fields when they are converted to strings in Salesforce.  Instead, we need to convert the string to ISO-8601 format before sending it to ManyWho.